### PR TITLE
Improve student activity registration system

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn
 httpx
 watchfiles
+pytest

--- a/src/README.md
+++ b/src/README.md
@@ -6,6 +6,7 @@ A super simple FastAPI application that allows students to view and sign up for 
 
 - View all available extracurricular activities
 - Sign up for activities
+- Unregister from activities
 
 ## Getting Started
 
@@ -31,6 +32,15 @@ A super simple FastAPI application that allows students to view and sign up for 
 | ------ | ----------------------------------------------------------------- | ------------------------------------------------------------------- |
 | GET    | `/activities`                                                     | Get all activities with their details and current participant count |
 | POST   | `/activities/{activity_name}/signup?email=student@mergington.edu` | Sign up for an activity                                             |
+| DELETE | `/activities/{activity_name}/signup?email=student@mergington.edu` | Unregister from an activity                                         |
+
+## Testing
+
+Run backend tests from the repository root:
+
+```
+python -m pytest tests -v
+```
 
 ## Data Model
 

--- a/src/app.py
+++ b/src/app.py
@@ -105,3 +105,22 @@ def signup_for_activity(activity_name: str, email: str):
     # Add student
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}
+
+
+@app.delete("/activities/{activity_name}/signup")
+def unregister_from_activity(activity_name: str, email: str):
+    """Unregister a student from an activity"""
+    # Validate activity exists
+    if activity_name not in activities:
+        raise HTTPException(status_code=404, detail="Activity not found")
+
+    # Get the specific activity
+    activity = activities[activity_name]
+
+    # Validate student is signed up
+    if email not in activity["participants"]:
+        raise HTTPException(status_code=404, detail="Student not registered for this activity")
+
+    # Remove student
+    activity["participants"].remove(email)
+    return {"message": f"Unregistered {email} from {activity_name}"}

--- a/src/app.py
+++ b/src/app.py
@@ -38,6 +38,42 @@ activities = {
         "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
         "max_participants": 30,
         "participants": ["john@mergington.edu", "olivia@mergington.edu"]
+    },
+    "Basketball Team": {
+        "description": "Competitive basketball team for intramural and league play",
+        "schedule": "Mondays and Wednesdays, 4:00 PM - 5:30 PM",
+        "max_participants": 15,
+        "participants": ["james@mergington.edu"]
+    },
+    "Tennis Club": {
+        "description": "Develop tennis skills and participate in matches",
+        "schedule": "Saturdays, 10:00 AM - 11:30 AM",
+        "max_participants": 10,
+        "participants": ["rachel@mergington.edu", "chris@mergington.edu"]
+    },
+    "Drama Club": {
+        "description": "Perform in theatrical productions and develop acting skills",
+        "schedule": "Thursdays, 4:00 PM - 5:30 PM",
+        "max_participants": 25,
+        "participants": ["anna@mergington.edu"]
+    },
+    "Art Studio": {
+        "description": "Explore painting, drawing, and sculpture techniques",
+        "schedule": "Tuesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 16,
+        "participants": ["lucas@mergington.edu", "maya@mergington.edu"]
+    },
+    "Debate Team": {
+        "description": "Develop critical thinking and public speaking through competitive debate",
+        "schedule": "Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 14,
+        "participants": ["jason@mergington.edu"]
+    },
+    "Science Club": {
+        "description": "Conduct experiments and explore advanced scientific concepts",
+        "schedule": "Fridays, 4:00 PM - 5:30 PM",
+        "max_participants": 18,
+        "participants": ["nina@mergington.edu", "david@mergington.edu"]
     }
 }
 
@@ -61,6 +97,10 @@ def signup_for_activity(activity_name: str, email: str):
 
     # Get the specific activity
     activity = activities[activity_name]
+
+    # Validate student is not already signed up
+    if email in activity["participants"]:
+        raise HTTPException(status_code=400, detail="Student already signed up for this activity")
 
     # Add student
     activity["participants"].append(email)

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -12,6 +12,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
       // Clear loading message
       activitiesList.innerHTML = "";
+      activitySelect.innerHTML = '<option value="">-- Select an activity --</option>';
 
       // Populate activities list
       Object.entries(activities).forEach(([name, details]) => {
@@ -19,12 +20,39 @@ document.addEventListener("DOMContentLoaded", () => {
         activityCard.className = "activity-card";
 
         const spotsLeft = details.max_participants - details.participants.length;
+        const participantsList = details.participants.length
+          ? details.participants
+              .map(
+                (participant) => `
+                  <li class="participant-item">
+                    <span class="participant-email">${participant}</span>
+                    <button
+                      type="button"
+                      class="remove-participant-btn"
+                      data-activity="${name}"
+                      data-email="${participant}"
+                      title="Unregister participant"
+                      aria-label="Unregister ${participant} from ${name}"
+                    >
+                      &times;
+                    </button>
+                  </li>
+                `
+              )
+              .join("")
+          : "<li class=\"empty-participants\">No participants yet</li>";
 
         activityCard.innerHTML = `
           <h4>${name}</h4>
           <p>${details.description}</p>
           <p><strong>Schedule:</strong> ${details.schedule}</p>
           <p><strong>Availability:</strong> ${spotsLeft} spots left</p>
+          <div class="participants-section">
+            <p class="participants-title"><strong>Participants:</strong></p>
+            <ul class="participants-list">
+              ${participantsList}
+            </ul>
+          </div>
         `;
 
         activitiesList.appendChild(activityCard);
@@ -39,6 +67,22 @@ document.addEventListener("DOMContentLoaded", () => {
       activitiesList.innerHTML = "<p>Failed to load activities. Please try again later.</p>";
       console.error("Error fetching activities:", error);
     }
+  }
+
+  async function unregisterParticipant(activity, email) {
+    const response = await fetch(
+      `/activities/${encodeURIComponent(activity)}/signup?email=${encodeURIComponent(email)}`,
+      {
+        method: "DELETE",
+      }
+    );
+
+    const result = await response.json();
+    if (!response.ok) {
+      throw new Error(result.detail || "Failed to unregister participant");
+    }
+
+    return result;
   }
 
   // Handle form submission
@@ -62,6 +106,7 @@ document.addEventListener("DOMContentLoaded", () => {
         messageDiv.textContent = result.message;
         messageDiv.className = "success";
         signupForm.reset();
+        await fetchActivities();
       } else {
         messageDiv.textContent = result.detail || "An error occurred";
         messageDiv.className = "error";
@@ -78,6 +123,30 @@ document.addEventListener("DOMContentLoaded", () => {
       messageDiv.className = "error";
       messageDiv.classList.remove("hidden");
       console.error("Error signing up:", error);
+    }
+  });
+
+  activitiesList.addEventListener("click", async (event) => {
+    const removeButton = event.target.closest(".remove-participant-btn");
+    if (!removeButton) {
+      return;
+    }
+
+    const activity = removeButton.dataset.activity;
+    const email = removeButton.dataset.email;
+    removeButton.disabled = true;
+
+    try {
+      const result = await unregisterParticipant(activity, email);
+      messageDiv.textContent = result.message;
+      messageDiv.className = "success";
+      messageDiv.classList.remove("hidden");
+      await fetchActivities();
+    } catch (error) {
+      messageDiv.textContent = error.message;
+      messageDiv.className = "error";
+      messageDiv.classList.remove("hidden");
+      removeButton.disabled = false;
     }
   });
 

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -74,6 +74,72 @@ section h3 {
   margin-bottom: 8px;
 }
 
+.participants-section {
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px dashed #cfd8dc;
+}
+
+.participants-title {
+  margin-bottom: 8px;
+  color: #1a237e;
+}
+
+.participants-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.participants-list li {
+  margin-bottom: 6px;
+  color: #2f3b46;
+}
+
+.participant-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 8px 10px;
+  border: 1px solid #dde4ea;
+  border-radius: 8px;
+  background: #ffffff;
+}
+
+.participant-email {
+  overflow-wrap: anywhere;
+}
+
+.remove-participant-btn {
+  width: 28px;
+  height: 28px;
+  border-radius: 999px;
+  border: 1px solid #ef9a9a;
+  background-color: #ffebee;
+  color: #c62828;
+  font-size: 20px;
+  line-height: 1;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.remove-participant-btn:hover {
+  background-color: #ffcdd2;
+}
+
+.remove-participant-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.empty-participants {
+  font-style: italic;
+  color: #607d8b;
+}
+
 .form-group {
   margin-bottom: 15px;
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,21 @@
+import copy
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src import app as app_module
+
+INITIAL_ACTIVITIES = copy.deepcopy(app_module.activities)
+
+
+@pytest.fixture(autouse=True)
+def reset_activities():
+    """Reset in-memory activities before each test for isolation."""
+    app_module.activities.clear()
+    app_module.activities.update(copy.deepcopy(INITIAL_ACTIVITIES))
+    yield
+
+
+@pytest.fixture
+def client():
+    return TestClient(app_module.app)

--- a/tests/test_activities.py
+++ b/tests/test_activities.py
@@ -1,0 +1,21 @@
+def test_get_activities_returns_all_activities(client):
+    response = client.get("/activities")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert isinstance(data, dict)
+    assert "Chess Club" in data
+
+
+def test_get_activities_has_expected_structure(client):
+    response = client.get("/activities")
+
+    assert response.status_code == 200
+    data = response.json()
+
+    for details in data.values():
+        assert "description" in details
+        assert "schedule" in details
+        assert "max_participants" in details
+        assert "participants" in details
+        assert isinstance(details["participants"], list)

--- a/tests/test_signup.py
+++ b/tests/test_signup.py
@@ -1,0 +1,32 @@
+def test_signup_adds_student_to_activity(client):
+    email = "new.student@mergington.edu"
+    activity = "Chess Club"
+
+    response = client.post(f"/activities/{activity}/signup", params={"email": email})
+
+    assert response.status_code == 200
+    assert response.json()["message"] == f"Signed up {email} for {activity}"
+
+    activities_response = client.get("/activities")
+    participants = activities_response.json()[activity]["participants"]
+    assert email in participants
+
+
+def test_signup_rejects_duplicate_registration(client):
+    email = "michael@mergington.edu"
+    activity = "Chess Club"
+
+    response = client.post(f"/activities/{activity}/signup", params={"email": email})
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Student already signed up for this activity"
+
+
+def test_signup_returns_not_found_for_missing_activity(client):
+    response = client.post(
+        "/activities/Nonexistent Activity/signup",
+        params={"email": "someone@mergington.edu"},
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Activity not found"

--- a/tests/test_unregister.py
+++ b/tests/test_unregister.py
@@ -1,0 +1,32 @@
+def test_unregister_removes_student_from_activity(client):
+    email = "michael@mergington.edu"
+    activity = "Chess Club"
+
+    response = client.delete(f"/activities/{activity}/signup", params={"email": email})
+
+    assert response.status_code == 200
+    assert response.json()["message"] == f"Unregistered {email} from {activity}"
+
+    activities_response = client.get("/activities")
+    participants = activities_response.json()[activity]["participants"]
+    assert email not in participants
+
+
+def test_unregister_returns_not_found_for_missing_activity(client):
+    response = client.delete(
+        "/activities/Nonexistent Activity/signup",
+        params={"email": "someone@mergington.edu"},
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Activity not found"
+
+
+def test_unregister_returns_not_found_when_student_not_registered(client):
+    response = client.delete(
+        "/activities/Chess Club/signup",
+        params={"email": "not-registered@mergington.edu"},
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Student not registered for this activity"


### PR DESCRIPTION
This pull request adds support for unregistering students from extracurricular activities, improves participant display and management in the UI, and introduces comprehensive backend testing. The main changes include new API endpoints and logic for unregistering, enhancements to the frontend for participant management, expanded activity data, and robust test coverage.

**Backend functionality enhancements:**

* Added a new `DELETE /activities/{activity_name}/signup` endpoint and corresponding logic in `app.py` to allow students to unregister from activities, including validation for activity existence and registration status. [[1]](diffhunk://#diff-e1d5879ce3e222eb0cdd43051fb8c34c00796467acb091d0b3fa939ee3355cb5R9) [[2]](diffhunk://#diff-e1d5879ce3e222eb0cdd43051fb8c34c00796467acb091d0b3fa939ee3355cb5R35-R43) [[3]](diffhunk://#diff-04791d82dd15fdd480f084d7ef65a10789fa5012cb7935f76080763444d48a00R101-R126)
* Expanded the in-memory activities data in `app.py` with several new clubs and teams, each with participants and details.

**Frontend improvements:**

* Updated `app.js` to display participants for each activity, including a list with remove buttons for unregistering, and integrated the new unregister API endpoint. [[1]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R15-R55) [[2]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R72-R87) [[3]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R129-R152)
* Improved participant section styling in `styles.css` for better user experience and clarity.

**Testing and documentation:**

* Added backend tests for activity listing, signup, and unregister features, including fixtures for test isolation in `conftest.py`, and new test files for signup and unregister scenarios. [[1]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128R1-R21) [[2]](diffhunk://#diff-1296adb14376e606bd4f15dbb75f86149ab573e22b6ad4987870b03bc16dbcf5R1-R21) [[3]](diffhunk://#diff-61ec098b3ee112a73dd8fad6565ff42d7189664d993b15b6e07d6ae5c718501eR1-R32) [[4]](diffhunk://#diff-21ccd8203cab33acf5126429131ad0a82f90f5710a8dd086d8974da3fb420462R1-R32)
* Updated `README.md` to document the new unregister endpoint and provide instructions for running tests.